### PR TITLE
Upgrade sdk-core to fix liquidity page crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@ethersproject/experimental": "^5.2.0",
     "@ixswap1/default-token-list": "^1.3.8",
-    "@ixswap1/sdk-core": "^1.0.0",
+    "@ixswap1/sdk-core": "^1.3.2",
     "@ixswap1/v2-core": "^1.0.11",
     "@ixswap1/v2-periphery": "^1.0.10",
     "@ixswap1/v2-sdk": "^1.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,10 +2048,22 @@
   resolved "https://registry.yarnpkg.com/@ixswap1/lib/-/lib-1.3.0.tgz#0a8e8bafa0ca6783c7c254338fda8b41f5b83b19"
   integrity sha512-30MpT4gc5oe6Lh2bWk0ldJND5D0YIiwUTbvpymyVx61twvQHyqYZEWcgi3GTxxKT6nkyNJIV9dwA7shLqlBKPw==
 
-"@ixswap1/sdk-core@1.x.x", "@ixswap1/sdk-core@^1.0.0":
+"@ixswap1/sdk-core@1.x.x":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@ixswap1/sdk-core/-/sdk-core-1.3.1.tgz#e140d8870ae9ba73ada6372f90410ed4e8510170"
   integrity sha512-M1Kc1BBwdOjokZ+oX619D041VJP0LBZTVKGGLxCLb5mAnsedHTX+42T5a9wnXGSxD4eMS8AsmOXc74/N1qz+ew==
+  dependencies:
+    "@ethersproject/address" "^5.0.2"
+    big.js "^5.2.2"
+    decimal.js-light "^2.5.0"
+    jsbi "^3.1.4"
+    tiny-invariant "^1.1.0"
+    toformat "^2.0.0"
+
+"@ixswap1/sdk-core@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@ixswap1/sdk-core/-/sdk-core-1.3.2.tgz#6190e791416090d9048eaf1214a09323637bfa40"
+  integrity sha512-m5XuqBWeahdItwv8cRyNPO5sNQ6xpwBXfDvMsCgz8BlD4/gReMgL2fofKL/zpQbPKBnj9nUMV7FbctGwE+vDUQ==
   dependencies:
     "@ethersproject/address" "^5.0.2"
     big.js "^5.2.2"


### PR DESCRIPTION
Liquidity page is crashing due to the `WETH9` address is undefined.

SDK-core : v1.3.2: https://github.com/IX-Swap/sdk-core/commit/435d5c9858de5918dbb170ae44a4eeb793f99d21