### PR TITLE
Ixspd1 34 Fix inssuficient balance bug on launchpad while token balance is still loading

### DIFF
--- a/src/components/LaunchpadOffer/InvestDialog/utils/ConvertationField.tsx
+++ b/src/components/LaunchpadOffer/InvestDialog/utils/ConvertationField.tsx
@@ -11,15 +11,13 @@ import { Option, useTokensList } from 'hooks/useTokensList'
 import { useCurrency } from 'hooks/Tokens'
 
 import { useSimpleTokenBalanceWithLoading } from 'state/wallet/hooks'
-import { useFormatOfferValue, useDerivedBalanceInfo } from 'state/launchpad/hooks'
+import { useDerivedBalanceInfo } from 'state/launchpad/hooks'
 import { text35 } from 'components/LaunchpadMisc/typography'
 import CurrencyLogo from 'components/CurrencyLogo'
 import { Currency } from '@ixswap1/sdk-core'
 import Loader from 'components/Loader'
 import { RowBetween } from 'components/Row'
-import { InvestFormSubmitButton } from './InvestSubmitButton'
 import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
-import { KycLightDocPreviewModal } from 'components/KycLightDocPreviewModal'
 import { BuyModal } from '../BuyModal'
 
 interface Props {
@@ -85,28 +83,19 @@ export const useGetWarning = (offer: Offer, isCheckBalance = false) => {
 export const ConvertationField: React.FC<Props> = (props) => {
   const theme = useTheme()
 
-  const {
-    tokenPrice,
-    tokenAddress,
-    tokenSymbol,
-    investingTokenAddress,
-    investingTokenSymbol,
-    investingTokenDecimals,
-    decimals,
-  } = props.offer
+  const { tokenPrice, tokenAddress, tokenSymbol, investingTokenAddress, investingTokenSymbol, investingTokenDecimals } =
+    props.offer
 
   const { tokensOptions, secTokensOptions } = useTokensList()
   const mixedTokens = React.useMemo(() => [...tokensOptions, ...secTokensOptions], [tokensOptions, secTokensOptions])
 
   const getWarning = useGetWarning(props.offer, true)
-  const formatedValue = useFormatOfferValue()
   const insufficientWarning = `Insufficient ${investingTokenSymbol} balance`
 
   const [inputValue, setInputValue] = React.useState('')
   const [warning, setWarning] = React.useState('')
   const { account } = useActiveWeb3React()
   const inputCurrency = useCurrency(investingTokenAddress)
-  // const balance = useCurrencyBalance(account ?? undefined, inputCurrency ?? undefined)
   const { amount: balance, loading: balanceIsLoading } = useSimpleTokenBalanceWithLoading(
     account,
     inputCurrency,
@@ -114,8 +103,6 @@ export const ConvertationField: React.FC<Props> = (props) => {
   )
   const [openPreviewModal, setPreviewModal] = React.useState(false)
   const isSufficientBalanceFn = useDerivedBalanceInfo(props.offer.id)
-
-  console.info('balance is loading', balanceIsLoading)
 
   const changeValue = (value: string) => {
     setInputValue(value)

--- a/src/components/LaunchpadOffer/InvestDialog/utils/ConvertationField.tsx
+++ b/src/components/LaunchpadOffer/InvestDialog/utils/ConvertationField.tsx
@@ -10,11 +10,11 @@ import { useActiveWeb3React } from 'hooks/web3'
 import { Option, useTokensList } from 'hooks/useTokensList'
 import { useCurrency } from 'hooks/Tokens'
 
-import { useCurrencyBalance, useSimpleTokenBalanceWithLoading } from 'state/wallet/hooks'
+import { useSimpleTokenBalanceWithLoading } from 'state/wallet/hooks'
 import { useFormatOfferValue, useDerivedBalanceInfo } from 'state/launchpad/hooks'
 import { text35 } from 'components/LaunchpadMisc/typography'
 import CurrencyLogo from 'components/CurrencyLogo'
-import { Currency, CurrencyAmount } from '@ixswap1/sdk-core'
+import { Currency } from '@ixswap1/sdk-core'
 import Loader from 'components/Loader'
 import { RowBetween } from 'components/Row'
 import { InvestFormSubmitButton } from './InvestSubmitButton'
@@ -120,9 +120,6 @@ export const ConvertationField: React.FC<Props> = (props) => {
   const changeValue = (value: string) => {
     setInputValue(value)
     const isBalanceSufficient = isSufficientBalanceFn(value, inputCurrency, balance) || false
-    console.log('Balance', balance?.toExact(), balance?.toFixed(), balance?.toSignificant())
-    console.log('Value', value)
-    console.log('isBalanceSufficient', isBalanceSufficient)
     const newWarning = getWarning(value, isBalanceSufficient, props.availableToInvest)
 
     setWarning(newWarning)
@@ -136,17 +133,18 @@ export const ConvertationField: React.FC<Props> = (props) => {
     )
   }
 
+  // DEBUGGING CODE - DON'T REMOVE THIS
   const start: any = useRef<number>(0)
   const end: any = useRef<number>(0)
   useMemo(() => {
     if (balanceIsLoading && start.current == 0) {
       start.current = performance.now()
-      console.info('start', start)
+      console.log('start', start)
     }
 
     if (!balanceIsLoading && end.current == 0) {
       end.current = performance.now()
-      console.log('\x1B[31mtime to load balance', (end.current - start.current) / 1000)
+      console.log('\x1B[31mTime to load balance', (end.current - start.current) / 1000)
       start.current = 0
       end.current = 0
     }

--- a/src/components/LaunchpadOffer/InvestDialog/utils/ConvertationField.tsx
+++ b/src/components/LaunchpadOffer/InvestDialog/utils/ConvertationField.tsx
@@ -96,7 +96,7 @@ export const ConvertationField: React.FC<Props> = (props) => {
   const [warning, setWarning] = React.useState('')
   const { account } = useActiveWeb3React()
   const inputCurrency = useCurrency(investingTokenAddress)
-  const { amount: balance, loading: balanceIsLoading } = useSimpleTokenBalanceWithLoading(
+  const { amount: balance, loading: isBalanceLoading } = useSimpleTokenBalanceWithLoading(
     account,
     inputCurrency,
     investingTokenAddress
@@ -124,19 +124,19 @@ export const ConvertationField: React.FC<Props> = (props) => {
   const start: any = useRef<number>(0)
   const end: any = useRef<number>(0)
   useMemo(() => {
-    if (balanceIsLoading && start.current == 0) {
+    if (isBalanceLoading && start.current == 0) {
       start.current = performance.now()
       console.log('start', start)
     }
 
-    if (!balanceIsLoading && end.current == 0) {
+    if (!isBalanceLoading && end.current == 0) {
       end.current = performance.now()
       console.log('\x1B[31mTime to load balance', (end.current - start.current) / 1000)
       start.current = 0
       end.current = 0
     }
     console.log('Balance updated', balance?.toExact(), balance?.toFixed(), balance?.toSignificant())
-  }, [balance, balanceIsLoading])
+  }, [balance, isBalanceLoading])
 
   const convertedValue = React.useMemo(() => {
     if (inputValue) {
@@ -179,6 +179,7 @@ export const ConvertationField: React.FC<Props> = (props) => {
         <InvestTextField
           type="number"
           onChange={changeValue}
+          disabled={isBalanceLoading}
           trailing={<CurrencyDropdown disabled value={offerInvestmentToken} />}
           caption={insufficientWarning === warning ? '' : warning === 'Loading' ? <Loader /> : warning}
           // height="85px"
@@ -191,6 +192,7 @@ export const ConvertationField: React.FC<Props> = (props) => {
           value={convertedValue}
           onChange={() => null}
           trailing={<CurrencyDropdown disabled value={offerToken} />}
+          disabled
           // height="85px"
           fontSize="20px"
           lineHeight="20px"


### PR DESCRIPTION
- use `useSimpleTokenBalanceWithLoading` hook to load balance instead of `useBalance`.  the hook should return a isLoading boolean which is used to set to the `disabled` props of the form inputs. Form inputs will be disabled while the balance is loading
- switch the `useSimpleTokenBalanceWithLoading` implementation from using multicall to regular contract call to speed up the query response time

https://investax.atlassian.net/browse/IXSPD1-34