### PR TITLE
Update usdc and sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "devDependencies": {
     "@ethersproject/experimental": "^5.2.0",
-    "@ixswap1/default-token-list": "^1.3.9",
+    "@ixswap1/default-token-list": "^1.4.1",
     "@ixswap1/sdk-core": "^1.3.2",
     "@ixswap1/v2-core": "^1.0.11",
     "@ixswap1/v2-periphery": "^1.0.10",

--- a/src/constants/lists.ts
+++ b/src/constants/lists.ts
@@ -1,6 +1,5 @@
 // used to mark unsupported tokens, these are hosted lists of unsupported tokens
 const COMPOUND_LIST = 'https://raw.githubusercontent.com/compound-finance/token-list/master/compound.tokenlist.json'
-const UMA_LIST = 'https://umaproject.org/uma.tokenlist.json'
 const AAVE_LIST = 'tokenlist.aave.eth'
 const SYNTHETIX_LIST = 'synths.snx.eth'
 const WRAPPED_LIST = 'wrapped.tokensoft.eth'
@@ -20,7 +19,6 @@ export const DEFAULT_LIST_OF_LISTS: string[] = [
   COMPOUND_LIST,
   AAVE_LIST,
   SYNTHETIX_LIST,
-  UMA_LIST,
   WRAPPED_LIST,
   SET_LIST,
   ROLL_LIST,

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -14,10 +14,11 @@ _axios.defaults.baseURL = API_URL
 
 _axios.interceptors.response.use(responseSuccessInterceptor, async function responseErrorInterceptor(error: any) {
   if (error.response.status !== OK_RESPONSE_CODE || error.response.status !== CREATED_RESPONSE_CODE) {
+    const method = error?.response?.config?.method
     // only log errors if the URL contain kyc
-    if (error?.response?.config?.url?.includes('kyc')) {
+    if (error?.response?.config?.url?.includes('kyc') && (method === 'post' || method === 'put')) {
       Sentry.addBreadcrumb({
-        category: 'api',
+        category: 'KYC',
         level: 'error',
         message: error?.response?.data?.message,
         data: error?.response?.data,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2038,10 +2038,10 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@ixswap1/default-token-list@^1.3.9":
-  version "1.3.9"
-  resolved "https://registry.yarnpkg.com/@ixswap1/default-token-list/-/default-token-list-1.3.9.tgz#b5a5f27592d5752cb4dda97ef24e19c05605d94a"
-  integrity sha512-vIVXyalHsA1gRRUcWWWuS0rlEGiKi2RDeMFCzmxnxjusv9403Rejgvohfy3SMNCKrj5B1KFBn7QA7D4WmVwH6g==
+"@ixswap1/default-token-list@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@ixswap1/default-token-list/-/default-token-list-1.4.1.tgz#c9ade701295dc0884151c963148a826a15ca2c09"
+  integrity sha512-omalg4VTb+O4bRTkFfGK/X0qyqOShUjFt+c902P13Gx86IvbgT/nTpPtWHvnycDR4Wy39MmphVSHT6FP78oBfQ==
 
 "@ixswap1/lib@1.x.x":
   version "1.3.0"


### PR DESCRIPTION
- Bump `default-token-list` version to display correct bridged USDC  info
- Add `KYC` category for API errors related to KYC
- Remove UMA token list as the link is broken https://investax-ze.sentry.io/issues/5016159586/?project=4506812121022464&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0