### PR TITLE
Ixspd1 990 fe dev issuance dashboard the registration result is not displayed immediately in the table after approving rejecting

### DIFF
--- a/src/components/LaunchpadIssuance/ManageOffer/presale/WhitelistList.tsx
+++ b/src/components/LaunchpadIssuance/ManageOffer/presale/WhitelistList.tsx
@@ -35,6 +35,8 @@ interface Props {
   startLoading: () => any
   stopLoading: () => any
   isLoading: boolean
+  startARLoading: () => any
+  stopARLoading: () => any
   pageSize: number
   setPageSize: (page: number) => void
   disabledManage: boolean
@@ -51,6 +53,8 @@ export const OfferWhitelistList = ({
   startLoading,
   stopLoading,
   isLoading,
+  startARLoading,
+  stopARLoading,
   pageSize,
   setPageSize,
   disabledManage,
@@ -67,8 +71,10 @@ export const OfferWhitelistList = ({
   const approveSelected = () => {
     if (actionsDisabled) return
     startLoading()
+    startARLoading()
     manageWhitelists.load(offerId, { approveIds: selected }).then(() => {
       stopLoading()
+      stopARLoading()
       setSelected([])
       refreshWhitelists()
     })
@@ -76,8 +82,10 @@ export const OfferWhitelistList = ({
   const rejectSelected = () => {
     if (actionsDisabled) return
     startLoading()
+    startARLoading()
     manageWhitelists.load(offerId, { rejectIds: selected }).then(() => {
       stopLoading()
+      stopARLoading
       setSelected([])
       refreshWhitelists()
     })

--- a/src/components/LaunchpadIssuance/ManageOffer/presale/index.tsx
+++ b/src/components/LaunchpadIssuance/ManageOffer/presale/index.tsx
@@ -109,6 +109,8 @@ export const PresaleBlock = ({ offer }: Props) => {
           refreshWhitelists={() => {
             refreshWhitelists()
             setPage(1)
+            refreshApprovedRejectedLists()
+            setARListsPage(1)
           }}
           order={order}
           setOrder={setOrder}
@@ -117,6 +119,8 @@ export const PresaleBlock = ({ offer }: Props) => {
           startLoading={startLoading}
           stopLoading={stopLoading}
           isLoading={isLoading}
+          startARLoading={startARLoading}
+          stopARLoading={stopARLoading}
           pageSize={pageSize}
           setPageSize={setPageSize}
           disabledManage={disabledManage}


### PR DESCRIPTION
Description:
- Fix bug The registration result is not displayed immediately in the table after approving/rejecting

Bullet points of the changes:
- Pass Approved Rejected List's startARLoading and stopARLoading to OfferWhitelistList to reload the Approved Rejected table

Link to jira ticket:
https://investax.atlassian.net/browse/IXSPD1-990