### PR TITLE
Bug fix 116- The page crashes when user input the maximum project token amount to buy

### DIFF
--- a/src/components/LBP/utils/calculation.ts
+++ b/src/components/LBP/utils/calculation.ts
@@ -32,6 +32,11 @@ type GetPriceArgs = {
 }
 
 export const getPriceFromRawReservesAndWeights = (args: GetPriceArgs) => {
+  const zero = BigNumber.from(0)
+  if (args.currentAssetReserve.lte(zero) || args.currentShareReserve.lte(zero)) {
+    return '0'
+  }
+
   const numerator = expandTo18Decimals(args.currentAssetReserve, args.assetDecimals)
     .mul(utils.parseEther('1'))
     .div(args.currentAssetWeight)


### PR DESCRIPTION
## Description

The page crashes when user input the maximum project token amount to buy

![image](https://github.com/IX-Swap/interface/assets/118243127/b9444438-bc4a-45d9-a18f-da68b2f29f5f)


## Attached Links

1. Jira ticket:
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
