### PR TITLE
Bug fixed on lbp details page where if user disconnect the wallet.

### DIFF
--- a/src/components/LBP/InvestmentList/LbpCard.tsx
+++ b/src/components/LBP/InvestmentList/LbpCard.tsx
@@ -11,6 +11,7 @@ import { useKyc } from 'state/user/hooks'
 
 import Portal from '@reach/portal'
 import { KYCPrompt } from 'components/Launchpad/KYCPrompt'
+import { useWeb3React } from '@web3-react/core'
 
 interface Props {
   lbp: any
@@ -24,6 +25,7 @@ export const LbpCard: React.FC<Props> = ({ lbp }) => {
   const history = useHistory()
   const theme = useTheme()
   const { isChangeRequested, isPending, isDraft, isRejected } = useKyc()
+  const { account } = useWeb3React()
   const [showDetails, setShowDetails] = React.useState(false)
   const [color, setColor] = React.useState('')
   const [showKYCModal, setShowKYCModal] = React.useState(false)
@@ -37,12 +39,12 @@ export const LbpCard: React.FC<Props> = ({ lbp }) => {
   )
 
   const onClick = React.useCallback(() => {
-    if (isChangeRequested || isPending || isDraft || isRejected) {
+    if (!account || isChangeRequested || isPending || isDraft || isRejected) {
       toggleKYCModal()
     } else {
       history.push(`/lbp/${lbp.id}`)
     }
-  }, [isChangeRequested, isPending, isDraft, isRejected, history, lbp.id])
+  }, [!account, isChangeRequested, isPending, isDraft, isRejected, history, lbp.id])
 
   useEffect(() => {
     switch (lbp.status) {
@@ -64,6 +66,11 @@ export const LbpCard: React.FC<Props> = ({ lbp }) => {
 
   return (
     <>
+      {showKYCModal && (
+        <Portal>
+          <KYCPrompt />
+        </Portal>
+      )}
       <LbpCardContainer>
         <LbpCardImage src={lbp.banner?.public} />
 
@@ -124,11 +131,6 @@ export const LbpCard: React.FC<Props> = ({ lbp }) => {
               </InvestButton>
             )}
           </LbpCardFooter>
-          {showKYCModal && (
-            <Portal>
-              <KYCPrompt />
-            </Portal>
-          )}
         </LbpCardInfoContainer>
       </LbpCardContainer>
     </>

--- a/src/components/Launchpad/KYCPrompt/index.tsx
+++ b/src/components/Launchpad/KYCPrompt/index.tsx
@@ -63,6 +63,7 @@ export const KYCPrompt: React.FC<Props> = (props) => {
       toggleModal(false)
     }
   }, [account, !!kyc, isChangeRequested, isPending, isInProgress, isRejected, isAccredited, isDraft])
+  
 
   return (
     <Modal isOpen={isOpen} onDismiss={() => toggleModal(false)}>

--- a/src/pages/AppRoutes.tsx
+++ b/src/pages/AppRoutes.tsx
@@ -97,8 +97,8 @@ export const routeConfigs: RouteMapEntry[] = [
   /* LBP routes */
   { path: routes.lbpEdit, component: LBPForm },
   { path: routes.lbpDashboard, component: LbpDashboardPage, conditions: { isKycApproved: true } },
-  { path: routes.publicDetails, component: PublicDetails, conditions: { isKycApproved: true } },
-  { path: routes.adminDetails, component: AdminLbpDetail, conditions: { isKycApproved: true } },
+  { path: routes.publicDetails, component: PublicDetails, conditions: { chainIsSupported: true  } },
+  { path: routes.adminDetails, component: AdminLbpDetail, conditions: { isKycApproved: true} },
 
   { path: routes.nftList, component: ListNFT, conditions: { isWhitelisted: true } },
   {


### PR DESCRIPTION
## Description

Fixed a bug on the LBP details page where users could access the public details page after disconnecting their wallet.

## Changes

- Added a popup
- Restricted the URL
-

## Attached Links

1. Jira ticket:
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
