### PR TITLE
Removed iscreate logic, and fixed the issue if user clicks on submit button more than one time then id have been added

### DIFF
--- a/src/pages/LBP/LbpForm.tsx
+++ b/src/pages/LBP/LbpForm.tsx
@@ -159,9 +159,8 @@ export default function LBPForm() {
     try {
       let data = transformDataForSaving(formData)
       const res = await saveOrSubmitLbp(actionType, data)
-      const newId = res?.data?.id
-      if (newId || formData.id) {
-        const id = newId || formData.id
+      const id = res?.data?.id || formData.id
+      if (id) {
         setFormData((prevData) => ({ ...prevData, id }))
         data = { ...data, id }
       }


### PR DESCRIPTION


## Description

Removed the isCreate logic and fixed the issue where clicking the submit button multiple times would cause an error. Now, the user can submit the form correctly.

## Changes

- added a logic if from.id or res.data.id available then user can can sumit the form 
- from.data,id will work if user open the from in edit mode and res.data.id  will work if user will open the form in create mode


## Attached Links

1. Jira ticket: N/A
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
