### PR TITLE
IXSPD1-1337 Displayed the Resend Code button and the time counter under Verify Code button

### DIFF
--- a/src/pages/KYC/SecondaryContactOption.tsx
+++ b/src/pages/KYC/SecondaryContactOption.tsx
@@ -90,6 +90,7 @@ const SecondaryContactOption: React.FC<Props> = ({
       handleError('An unexpected error occurred')
     } finally {
       setIsButtonDisabled(false)
+      setTimer(60)
     }
   }
 
@@ -193,7 +194,7 @@ const SecondaryContactOption: React.FC<Props> = ({
               <TimerText>{`Get new code (${timer} seconds)`}</TimerText>
             ) : (
               <span style={{ cursor: 'pointer' }} onClick={handleGetNewCodeClick}>
-                {hasCodeError ? 'Get New Code' : ''}
+                {buttonText === 'Verify Code' ? 'Get New Code' : ''}
               </span>
             )}
           </TimerContainer>


### PR DESCRIPTION


## Description

This PR addresses an issue in the KYC form V2 where users did not have an option to resend the verification code if they did not receive it the first time. The following changes have been made to improve user experience:

## Changes

- After the user clicks the "Verify Code" button, a timer will be displayed, counting down from 60 seconds to 0.
- Once the timer reaches 0, the "Get New Code" button will be displayed.
- If the user clicks the "Get New Code" button, a new verification code will be sent to the provided email address.

## Attached Links

1. Jira ticket: https://investax.atlassian.net/browse/IXSPD1-1337
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
