### PR TITLE
fixed the annoucements bug

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -244,7 +244,7 @@ export default function Header() {
       )}
       {!isMobile && (
         <HeaderWrapper>
-          {cookies.annoucementsSeen && <Announcement />}
+          {!cookies.annoucementsSeen && <Announcement />}
           <HeaderFrame>
             <HeaderRow marginLeft={50}>
               <Title href={config?.defaultUrl || '.'}>


### PR DESCRIPTION
## Description

Announcements label was not closed after the clicks on close button issue have been fixed.

## Changes

- This is by mistake while the testing in FE side we made the reverse logic      {cookies.annoucementsSeen && <Announcement />} but forgot to revise this to      {!cookies.annoucementsSeen && <Announcement />} that’s why close button is behaving like this


## Attached Links

1. Jira ticket: N/A
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
