### PR TITLE
IXSPD1-1393 User cannot edit email if it was pre-filled after migrating the Draft KYC issue fixed

### DIFF
--- a/src/pages/KYC/IndividualKycFormV2.tsx
+++ b/src/pages/KYC/IndividualKycFormV2.tsx
@@ -182,11 +182,13 @@ export default function IndividualKycFormV2() {
 
   useEffect(() => {
     if (isPersonalVerified || kyc?.individual?.isEmailVerified) {
-      setInitialValues(initialValuesBusinessEmail)
+      setInitialValues({ ...initialValuesBusinessEmail, email: kyc?.individual?.email })
+    } else if (kyc?.individual?.email) {
+      setInitialValues({ ...individualFormV2InitialValues, email: kyc?.individual?.email })
     } else {
       setInitialValues(individualFormV2InitialValues)
     }
-  }, [isPersonalVerified, kyc?.individual?.isEmailVerified])
+  }, [isPersonalVerified, kyc?.individual?.isEmailVerified, kyc?.individual?.email])
 
   const validateValue = async (key: string, value: any) => {
     if (form.current.values[key] === value) {
@@ -352,7 +354,7 @@ export default function IndividualKycFormV2() {
                             kycVersion={'v2'}
                             id="emailAddressField"
                             label="Email address *"
-                            value={kyc?.individual?.email || values.email}
+                            value={values.email}
                             error={touched.email && errors.email}
                             onChange={(e: any) => onChangeInput('email', e.currentTarget.value, values, setFieldValue)}
                           />


### PR DESCRIPTION

## Description

IXSPD1-1393 User cannot edit email if it was pre-filled after migrating the Draft KYC issue fixed

## Changes

- changed the email value from the input and handled the value in use Effect so user can edit email

## Attached Links

1. Jira ticket: https://investax.atlassian.net/browse/IXSPD1-1393
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
