### PR TITLE
The IXSPD1-1399 and IXSPD1-1398 updates increase the token ticker length to 16 letters and expand the social network link options in issuance.

### DIFF
--- a/src/components/LaunchpadIssuance/IssuanceForm/Information/InformationForm.tsx
+++ b/src/components/LaunchpadIssuance/IssuanceForm/Information/InformationForm.tsx
@@ -352,12 +352,12 @@ export const InformationForm = (props: Props) => {
             setter={setFieldValue}
             touch={setFieldTouched}
             label="Token Ticker"
-            placeholder="2-6 letters"
+            placeholder="2-16 letters"
             disabled={edit}
             inputFilter={uppercaseFilter}
             value={values.tokenTicker}
             error={(touched.tokenTicker && errors.tokenTicker) as string}
-            maxLength={6}
+            maxLength={16}
           />
           <FormField
             field="decimals"

--- a/src/components/LaunchpadIssuance/IssuanceForm/Information/schema.ts
+++ b/src/components/LaunchpadIssuance/IssuanceForm/Information/schema.ts
@@ -108,7 +108,7 @@ export const createValidationSchema = (account: string | null | undefined) => {
       .string()
       .nullable()
       .min(STRING_MIN, getLongerThanOrEqual('Token symbol', STRING_MIN))
-      .max(6, 'Token symbol should be at most 6 charachters')
+      .max(16, 'Token symbol should be at most 6 charachters')
       .matches(/^(?=.*[a-zA-Z])[a-zA-Z\d]+$/, { message: 'Please enter only letters and numbers, min 1 letter' })
       .required(REQUIRED),
     tokenPrice: yup

--- a/src/components/LaunchpadIssuance/IssuanceForm/Information/schema.ts
+++ b/src/components/LaunchpadIssuance/IssuanceForm/Information/schema.ts
@@ -108,7 +108,7 @@ export const createValidationSchema = (account: string | null | undefined) => {
       .string()
       .nullable()
       .min(STRING_MIN, getLongerThanOrEqual('Token symbol', STRING_MIN))
-      .max(16, 'Token symbol should be at most 6 charachters')
+      .max(16, 'Token symbol should be at most 16 charachters')
       .matches(/^(?=.*[a-zA-Z])[a-zA-Z\d]+$/, { message: 'Please enter only letters and numbers, min 1 letter' })
       .required(REQUIRED),
     tokenPrice: yup

--- a/src/components/LaunchpadIssuance/IssuanceForm/Information/sections/AdditionalInformation.tsx
+++ b/src/components/LaunchpadIssuance/IssuanceForm/Information/sections/AdditionalInformation.tsx
@@ -49,6 +49,8 @@ export const AdditionalInformation: React.FC<Props> = ({ values, setter, touch, 
       { label: 'YouTube', value: SocialMediaType.youTube },
       { label: 'CoinMarketCap', value: SocialMediaType.coinMarketCap },
       { label: 'CoinGecko', value: SocialMediaType.coinGecko },
+      { label: 'Instagram', value: SocialMediaType.instagram },
+      { label: 'Others', value: SocialMediaType.others },
     ]
 
     const selectedLinks = new Set(values.social.map((x) => x.type))

--- a/src/components/LaunchpadIssuance/IssuanceForm/Information/types.ts
+++ b/src/components/LaunchpadIssuance/IssuanceForm/Information/types.ts
@@ -27,6 +27,8 @@ export enum SocialMediaType {
   youTube = 'youtube',
   coinMarketCap = 'coinmarketcap',
   coinGecko = 'coingecko',
+  instagram = 'instagram',
+  others = 'others',
 }
 
 export interface VideoLink {


### PR DESCRIPTION


## Description

The IXSPD1-1399 and IXSPD1-1398 updates increase the token ticker length to 16 letters and expand the social network link options in issuance.

## Changes

- Increased token ticker length to 16 letters.
- Added more social network link options in issuance.
-

## Attached Links

1. Jira ticket: https://investax.atlassian.net/browse/IXSPD1-1399
https://investax.atlassian.net/browse/IXSPD1-1398
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
