### PR TITLE
IXSPD1-1009 issue fixed on Custodian wallet field has incorrect position if the amount is too long

### DIFF
--- a/src/components/Vault/DepoistStatusInfo.tsx
+++ b/src/components/Vault/DepoistStatusInfo.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import { CopyAddress } from 'components/CopyAddress'
 import { Box } from 'rebass'
+import { formatNumberWithDecimals } from 'state/lbp/hooks'
 
 interface Props {
   originalSymbol?: string | null
@@ -17,7 +18,7 @@ export const DepoistStatusInfo = ({ fromAddress, toAddress, amount, originalSymb
     <Container>
       <Box>
         <Title>
-          Make Deposit {amount} {originalSymbol}:
+          Make Deposit {formatNumberWithDecimals(amount as string, 6)} {originalSymbol}:
         </Title>
         <CopyAddress
           address={fromAddress ?? ''}


### PR DESCRIPTION
## Description

IXSPD1-1009 issue fixed on Custodian wallet field has incorrect position if the amount is too long

## Changes

- made this 6 digits after the decimal 

## Attached Links

1. Jira ticket:  https://investax.atlassian.net/browse/IXSPD1-1009
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
