### PR TITLE
IXSPD1-1622 Replace legacy useApprove with useAllowance in Liquidity

### DIFF
--- a/src/pages/AddLiquidityV2/index.tsx
+++ b/src/pages/AddLiquidityV2/index.tsx
@@ -23,7 +23,7 @@ import { FixedHeightRow, MinimalPositionCard } from '../../components/PositionCa
 import { ButtonRow, RowFixed } from '../../components/Row'
 import TransactionConfirmationModal from '../../components/TransactionConfirmationModal'
 import { ZERO_PERCENT } from '../../constants/misc'
-import { ApprovalState, useApproveCallback } from '../../hooks/useApproveCallback'
+import { ApprovalState, useAllowanceV2 } from '../../hooks/useApproveCallback'
 import { useLiquidityRouterContract } from '../../hooks/useContract'
 import { useIsSwapUnsupported } from '../../hooks/useIsSwapUnsupported'
 import useTransactionDeadline from '../../hooks/useTransactionDeadline'
@@ -167,8 +167,20 @@ export default function AddLiquidity({
   const router = useLiquidityRouterContract()
 
   // check whether the user has approved the router on the tokens
-  const [approvalA, approveACallback] = useApproveCallback(parsedAmounts[Field.CURRENCY_A], router?.address)
-  const [approvalB, approveBCallback] = useApproveCallback(parsedAmounts[Field.CURRENCY_B], router?.address)
+  const amountToApproveA = parsedAmounts[Field.CURRENCY_A]
+  const amountToApproveB = parsedAmounts[Field.CURRENCY_B]
+  const tokenAddressA = amountToApproveA?.currency?.isToken ? amountToApproveA.currency.address : undefined
+  const tokenAddressB = amountToApproveB?.currency?.isToken ? amountToApproveB.currency.address : undefined
+  const [approvalA, approveACallback] = useAllowanceV2(
+    tokenAddressA,
+    amountToApproveA ? BigNumber.from(amountToApproveA?.quotient?.toString()) : BigNumber.from(0),
+    router?.address
+  )
+  const [approvalB, approveBCallback] = useAllowanceV2(
+    tokenAddressB,
+    amountToApproveB ? BigNumber.from(amountToApproveB?.quotient?.toString()) : BigNumber.from(0),
+    router?.address
+  )
 
   const addTransaction = useTransactionAdder()
 

--- a/src/pages/RemoveLiquidity/index.tsx
+++ b/src/pages/RemoveLiquidity/index.tsx
@@ -21,7 +21,7 @@ import { RowBetween } from '../../components/Row'
 import { Dots } from '../../components/swap/styleds'
 import TransactionConfirmationModal from '../../components/TransactionConfirmationModal'
 import { useCurrency } from '../../hooks/Tokens'
-import { ApprovalState, useApproveCallback } from '../../hooks/useApproveCallback'
+import { ApprovalState, useAllowanceV2 } from '../../hooks/useApproveCallback'
 import { useLiquidityRouterContract, usePairContract } from '../../hooks/useContract'
 import { UseERC20PermitState, useV2LiquidityTokenPermit } from '../../hooks/useERC20Permit'
 import useTransactionDeadline from '../../hooks/useTransactionDeadline'
@@ -104,7 +104,13 @@ export default function RemoveLiquidity({
     router?.address
   )
 
-  const [approval, approveCallback] = useApproveCallback(parsedAmounts[Field.LIQUIDITY], router?.address)
+  const amountToApprove = parsedAmounts[Field.LIQUIDITY]
+  const tokenAddress = amountToApprove?.currency?.isToken ? amountToApprove.currency.address : undefined
+  const [approval, approveCallback] = useAllowanceV2(
+    tokenAddress,
+    amountToApprove ? BigNumber.from(amountToApprove?.quotient?.toString()) : BigNumber.from(0),
+    router?.address
+  )
 
   // useEffect(() => {
   //   const getSignature = async () => {


### PR DESCRIPTION
## Description

Please describe the purpose of this pull request.

## Changes

- Replace legacy useApprove with useAllowance in Liquidity as it's slow and asks user to allow max uint256

## Attached Links

1. Jira ticket: https://investax.atlassian.net/browse/IXSPD1-1622
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
