### PR TITLE
IXSPD1-1641 Fix the popup is not correct when user changes to the network that is…

### DIFF
--- a/src/components/LBP/PublicDetails/MiddleSection.tsx
+++ b/src/components/LBP/PublicDetails/MiddleSection.tsx
@@ -17,6 +17,8 @@ import RedeemedSideBar from './RedeemedSideBar'
 import { useTokenContract } from 'hooks/useContract'
 import SideBarPaused from './SideBarPaused'
 import { isMobile } from 'react-device-detect'
+import { checkWrongChain } from 'chains'
+import { useWeb3React } from '@web3-react/core'
 
 interface MiddleSectionProps {
   lbpData: LbpFormValues | null
@@ -53,13 +55,15 @@ const MoreText = styled.span`
 
 const MiddleSection: React.FC<MiddleSectionProps> = ({ lbpData, statsData }) => {
   const shareTokenContract = useTokenContract(lbpData?.shareAddress ?? '')
+  const { chainId } = useWeb3React()
 
   const [showMore, setShowMore] = useState(false)
   const [shareSymbol, setShareSymbol] = useState<string>('')
 
   const sampleText = useMemo(() => `${lbpData?.description}`, [lbpData])
-
   const isTextLong = useMemo(() => sampleText.length > 300, [sampleText])
+  const network = lbpData?.network ?? ''
+  const { isWrongChain } = checkWrongChain(chainId, network)
 
   const SideBarByStatus = useMemo(() => {
     switch (lbpData?.status) {
@@ -96,8 +100,10 @@ const MiddleSection: React.FC<MiddleSectionProps> = ({ lbpData, statsData }) => 
       }
     }
 
-    fetchShareSymbol()
-  }, [lbpData?.shareAddress])
+    if (!isWrongChain) {
+      fetchShareSymbol()
+    }
+  }, [lbpData?.shareAddress, isWrongChain])
 
   return (
     <MiddleSectionWrapper>

--- a/src/pages/LBP/PublicDetails.tsx
+++ b/src/pages/LBP/PublicDetails.tsx
@@ -11,8 +11,6 @@ import { LoaderThin } from 'components/Loader/LoaderThin'
 import { Loader } from 'components/AdminTransactionsTable'
 import { useKYCState } from 'state/kyc/hooks'
 import { KYCStatuses } from 'pages/KYC/enum'
-import { TGE_CHAINS_WITH_SWAP } from 'constants/addresses'
-import AppBody from 'pages/AppBody'
 import { checkWrongChain } from 'chains'
 import { CenteredFixed } from 'components/LaunchpadMisc/styled'
 import { NetworkNotAvailable } from 'components/Launchpad/NetworkNotAvailable'
@@ -33,7 +31,6 @@ const PublicDetails: React.FC = () => {
   const history = useHistory()
 
   const isKycApproved = kyc?.status === KYCStatuses.APPROVED ?? false
-  const blurred = !chainId || !TGE_CHAINS_WITH_SWAP.includes(chainId)
   const network = lbpData?.network ?? ''
   const { isWrongChain, expectChain } = checkWrongChain(chainId, network)
 
@@ -61,11 +58,7 @@ const PublicDetails: React.FC = () => {
     }
   }, [isLoading, account, isKycApproved, history])
 
-  return blurred ? (
-    <AppBody blurred>
-      <div></div>
-    </AppBody>
-  ) : (
+  return (
     <>
       {isLoading ? (
         <Loader>

--- a/src/pages/LaunchpadOffer/index.tsx
+++ b/src/pages/LaunchpadOffer/index.tsx
@@ -21,8 +21,6 @@ import { FilledButton } from 'components/LaunchpadMisc/buttons'
 import { MEDIA_WIDTHS } from 'theme'
 import { routes } from 'utils/routes'
 import Header from 'components/Header'
-import { NotAvailablePage } from 'components/NotAvailablePage'
-import { detectWrongNetwork } from 'utils'
 import { useWhitelabelState } from 'state/whitelabel/hooks'
 import WhiteLabelFooter from 'components/WhiteLabelFooter'
 import { checkWrongChain } from 'chains'
@@ -86,18 +84,6 @@ export default function LaunchpadOffer() {
       <Centered>
         <ErrorTitle>{offer.error || 'Offer not found'}</ErrorTitle>
       </Centered>
-    )
-  }
-
-  const blurred = detectWrongNetwork(chainId)
-
-  if (blurred) {
-    return (
-      <Portal>
-        <CenteredFixed width="100vw" height="100vh">
-          <NotAvailablePage />
-        </CenteredFixed>
-      </Portal>
     )
   }
 


### PR DESCRIPTION
… not Sepolia and Amoy when opening a Launchpad deal

## Description

Please describe the purpose of this pull request.

## Changes

- The popup is not correct when user changes to the network that is not Sepolia and Amoy when opening a Launchpad deal


## Attached Links

1. Jira ticket: https://investax.atlassian.net/browse/IXSPD1-1641
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
