### PR TITLE
IXSPD1-1674D isplayed token ticker instead of currency on Claim Successful dashboard

### DIFF
--- a/src/components/LaunchpadOffer/InvestDialog/content/Closed.tsx
+++ b/src/components/LaunchpadOffer/InvestDialog/content/Closed.tsx
@@ -122,7 +122,7 @@ export const ClosedStage: React.FC<Props> = (props) => {
           {!amountLoading && !amountError && (
             <MyInvestmentAmount>
               {isSuccessfull ? amountClaim : amount}&nbsp;
-              {getTokenSymbol(network, investingTokenSymbol)}
+              {isSuccessfull ? getTokenSymbol(network, tokenSymbol) : getTokenSymbol(network, investingTokenSymbol)}
             </MyInvestmentAmount>
           )}
           {amountError}


### PR DESCRIPTION


## Description
IXSPD1-1674D isplayed token ticker instead of currency on Claim Successful dashboard

## Changes

- update the logic if isSuccessfull then getTokenSymbol with tokenSymbol else investingTokenSymbol

## Attached Links

1. Jira ticket: https://investax.atlassian.net/browse/IXSPD1-1674
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
