### PR TITLE
XSPD1-1700 issue fixed Don't fill in the current time if user closes the date picker without selecting

### DIFF
--- a/src/components/LaunchpadIssuance/IssuanceForm/shared/fields/DateRangeField.tsx
+++ b/src/components/LaunchpadIssuance/IssuanceForm/shared/fields/DateRangeField.tsx
@@ -205,6 +205,7 @@ export const DateRangeField: React.FC<Props> = (props) => {
   }, [range, props.mode, props.dateFormat])
 
   React.useEffect(() => {
+    setDateErrorText(' ')
     if (props.value !== undefined) {
       if (props.mode === 'single') {
         setRange([moment(props.value as Date)])
@@ -221,6 +222,7 @@ export const DateRangeField: React.FC<Props> = (props) => {
     setStartTime(moment().startOf('day'))
     setEndTime(moment().startOf('day'))
     setShowPicker(false)
+
     if (typeof props.onError === 'function') {
       try {
         props.onError(props.field || '', dateErrorText || '')


### PR DESCRIPTION

## Description

XSPD1-1700 issue fixed Don't fill in the current time if user closes the date picker without selecting

## Changes

- just update the error state

## Attached Links

1. Jira ticket: https://investax.atlassian.net/browse/IXSPD1-1700
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
