### PR TITLE
Fix passing wrong network name to create liquidity pool API

### DIFF
--- a/src/chains.ts
+++ b/src/chains.ts
@@ -144,6 +144,17 @@ export enum NetworkName {
   POLYGON = 'polygon',
 }
 
+// chainIdToNetworkName covert chainId to network name regardless of whether it is testnet or mainnet
+export const chainIdToNetworkName = (chainId: number): string => {
+  for (const [network, chains] of Object.entries(Chains)) {
+    if (chains.includes(chainId)) {
+      return network
+    }
+  }
+
+  return ''
+}
+
 export const Chains = {
   // network name : tesnet, mainnet
   [NetworkName.BASE]: [SupportedChainId.BASE_SEPOLIA, SupportedChainId.BASE],

--- a/src/pages/AddLiquidityV2/index.tsx
+++ b/src/pages/AddLiquidityV2/index.tsx
@@ -53,6 +53,7 @@ import styled from 'styled-components/macro'
 import { isMobile } from 'react-device-detect'
 import Modal from 'components/Modal'
 import ConnectionDialog from 'components/Launchpad/Wallet/ConnectionDialog'
+import { chainIdToNetworkName } from 'chains'
 
 const DEFAULT_ADD_V2_SLIPPAGE_TOLERANCE = new Percent(50, 10_000)
 
@@ -269,7 +270,7 @@ export default function AddLiquidity({
                 tokenId: secTokenId,
                 token0: currencyA.wrapped.address,
                 token1: currencyB.wrapped.address,
-                network: NETWORK_NAMES[chainId],
+                network: chainIdToNetworkName(chainId),
                 blockNumber: res.events[last].blockNumber,
                 decimals: pair?.liquidityToken?.decimals || 18,
                 txHash: response.hash,


### PR DESCRIPTION
## Description



Fix passing wrong network name to create liquidity pool API
I Reused the current ChainNames and implemented the `chainIdToNetwork` function

```typescript
export enum NetworkName {
  BASE = 'base',
  POLYGON = 'polygon',
}

export const Chains = {
  // network name : tesnet, mainnet
  [NetworkName.BASE]: [SupportedChainId.BASE_SEPOLIA, SupportedChainId.BASE],
  [NetworkName.POLYGON]: [SupportedChainId.AMOY, SupportedChainId.MATIC],
}
```



## Attached Links

1. Jira ticket:
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
