### PR TITLE
issue fixed on  Cannot delete completely default 'event name' on create payout form

### DIFF
--- a/src/pages/CreatePayoutEvent/PayoutEventBlock.tsx
+++ b/src/pages/CreatePayoutEvent/PayoutEventBlock.tsx
@@ -58,12 +58,6 @@ export const PayoutEventBlock: FC<Props> = ({
 
   const toggleIsWarningOpen = () => setIsWarningOpen((state) => !state)
 
-  useEffect(() => {
-    const { title, secToken, type } = values
-    if (!title && secToken?.value && type) {
-      onValueChange('title', `${type} payout event for ${secToken.label}`)
-    }
-  }, [values])
 
   const onDelete = () => {
     toggleIsWarningOpen()


### PR DESCRIPTION

## Description

issue fixed on  Cannot delete completely default 'event name' on create payout form

## Changes

- issue fixed on  Cannot delete completely default 'event name' on create payout form

## Attached Links

1. Jira ticket: https://investax.atlassian.net/browse/IXSPD1-1795
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
