### PR TITLE
Minor updates on payout detail page event with airdrop type

### DIFF
--- a/src/pages/PayoutItem/History/index.tsx
+++ b/src/pages/PayoutItem/History/index.tsx
@@ -83,6 +83,7 @@ const Row: FC<RowProps> = ({ item }) => {
   const { payoutToken } = payoutEvent
   const currency = useCurrency(payoutToken)
   const { chainId } = useActiveWeb3React()
+  
 
   return (
     <StyledBodyRow>
@@ -95,11 +96,17 @@ const Row: FC<RowProps> = ({ item }) => {
         <Box>{Number(sum).toFixed(4)}</Box>
       </Flex>
       <div>{`${formatDate(createdAt)} - ${dayjs(createdAt).format('HH:mm')}`}</div>
-      <StyledView>
-        <ExternalLink href={getExplorerLink(chainId || 137, txHash, ExplorerDataType.TRANSACTION)}>
-          <EyeIcon stroke="#B8B8CC" />
-        </ExternalLink>
-      </StyledView>
+      {txHash ? (
+        <StyledView>
+          <ExternalLink href={getExplorerLink(chainId || 137, txHash, ExplorerDataType.TRANSACTION)}>
+            <EyeIcon stroke="#B8B8CC" />
+          </ExternalLink>
+        </StyledView>
+      ) : (
+        <Loader>
+          <LoaderThin size={12} />
+        </Loader>
+      )}
     </StyledBodyRow>
   )
 }
@@ -137,4 +144,11 @@ const StyledView = styled(Flex)`
   svg {
     width: 14px;
   }
+`
+
+const Loader = styled.div`
+  display: flex;
+  margin-left: 20px;
+  align-items: left;
+  justify-content: left;
 `

--- a/src/pages/PayoutItem/PayoutHeader.tsx
+++ b/src/pages/PayoutItem/PayoutHeader.tsx
@@ -49,8 +49,12 @@ export const PayoutHeader: FC<Props> = ({ payout, isMyPayout }) => {
           <StyledSummaryBlock>
             <TokenInformationContainer>
               <TitleContent>
-                <TokenNetwork token={secToken || {}} network={secToken?.network || ''} />
-                <SecTokenLink to={routes.securityToken(secToken?.catalogId)}>
+                {secToken ? <TokenNetwork token={secToken || {}} network={secToken?.network || ''} /> : null}
+
+                <SecTokenLink
+                  style={{ marginLeft: secToken ? '14px' : '0px' }}
+                  to={routes.securityToken(secToken?.catalogId)}
+                >
                   <Trans>{title}</Trans>
                   <span className="secTokenLinkSymbol">{secToken?.originalSymbol ?? secToken?.symbol}</span>
                 </SecTokenLink>


### PR DESCRIPTION
## Description

Minor updates on payout detail page event with airdrop type

## Changes

- if secToken is available the display the logo 
- if txHash is not available then display the loader

## Attached Links

1. Jira ticket: https://investax.atlassian.net/browse/IXSPD1-1932
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
