### PR TITLE
Issue fixed USer should be able to assign new SEC on user permission even when they have active payout

### DIFF
--- a/src/components/UsersList/UserModal.tsx
+++ b/src/components/UsersList/UserModal.tsx
@@ -57,19 +57,12 @@ export const UserModal: FC<Props> = ({ item, close, filters }) => {
   const tokensOptions = useMemo((): Record<number, Option> => {
     if (secTokens?.length) {
       return secTokens.reduce((acc, token) => {
-        const isDisabled = Boolean(
-          (item?.managerOf || []).find(({ token }) =>
-            Boolean(token?.payoutEvents.find(({ secTokenId }) => secTokenId === token.id))
-          )
-        )
-
         return {
           ...acc,
           [token.id]: {
             label: token.symbol,
             value: token.id,
             icon: <CurrencyLogo currency={new WrappedTokenInfo(token)} />,
-            isDisabled,
           },
         }
       }, {})

--- a/src/components/UsersList/index.tsx
+++ b/src/components/UsersList/index.tsx
@@ -117,7 +117,12 @@ export const UsersList: FC = () => {
       {usersList.items.length > 0 ? (
         <>
           <Table body={<Body changeUser={changeUser} items={usersList.items} />} header={<Header />} />
-          <Pagination totalPages={usersList.totalPages} page={usersList.page || 1} onPageChange={onPageChange} />
+          <Pagination
+            totalPages={usersList.totalPages}
+            page={usersList.page || 1}
+            onPageChange={onPageChange}
+            totalItems={usersList.totalItems}
+          />
         </>
       ) : (
         <NoData>
@@ -178,7 +183,7 @@ const TokenListPreview = (props: TokenListPreviewProps) => {
 const Row: FC<RowProps> = ({ item, changeUser }) => {
   const [expanded, handleExpanded] = useState(false)
   const { ethAddress, role, username, isWhitelisted, managerOf, whiteLabelConfig } = item
-  const needAccordion = role === ROLES.TOKEN_MANAGER  || role === ROLES.ADMIN && Boolean(managerOf?.length)
+  const needAccordion = role === ROLES.TOKEN_MANAGER || (role === ROLES.ADMIN && Boolean(managerOf?.length))
   const toggleAccordion = () => {
     if (needAccordion) {
       handleExpanded((state) => !state)


### PR DESCRIPTION


## Description

Issue fixed USer should be able to assign new SEC on user permission even when they have active payout and fixed the pagination on user list tables

## Changes

- Issue fixed USer should be able to assign new SEC on user permission even when they have active payout
- Fixed the pagination on user list tables

## Attached Links

1. Jira ticket: https://investax.atlassian.net/browse/IXSPD1-1865
2. Documents:
3. Demo UI 
 a) Issue fixed USer should be able to assign new SEC on user permission even when they have active payout
<img width="1110" alt="Screenshot 2024-09-12 at 11 57 05 AM" src="https://github.com/user-attachments/assets/ff809bae-2b4f-4505-b2ed-9d3ff81ba530">

 b) Fixed the pagination on user list tables
 
<img width="660" alt="image" src="https://github.com/user-attachments/assets/b82c3ac0-5ceb-4503-a873-319f3acc5481">



## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
