### PR TITLE
issue fixed Wrong SEC token in user view when includeOriginSupply= false on header

### DIFF
--- a/src/pages/PayoutItem/PayoutHeader.tsx
+++ b/src/pages/PayoutItem/PayoutHeader.tsx
@@ -56,7 +56,7 @@ export const PayoutHeader: FC<Props> = ({ payout, isMyPayout }) => {
                   to={routes.securityToken(secToken?.catalogId)}
                 >
                   <Trans>{title}</Trans>
-                  <span className="secTokenLinkSymbol">{secToken?.originalSymbol ?? secToken?.symbol}</span>
+                  <span className="secTokenLinkSymbol">{payout.includeOriginSupply ? secToken?.originalSymbol : secToken?.symbol}</span>
                 </SecTokenLink>
               </TitleContent>
               <ReadMoreContainer>


### PR DESCRIPTION

## Description

issue fixed Wrong SEC token in user view when includeOriginSupply= false on header

## Changes

- issue fixed Wrong SEC token in user view when includeOriginSupply= false on header

## Attached Links

1. Jira ticket:  https://investax.atlassian.net/browse/IXSPD1-1948
2. Documents:



## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
