### PR TITLE
IXSPD1-1990: Fix bug can't sign message

### DIFF
--- a/src/hooks/personalSign.ts
+++ b/src/hooks/personalSign.ts
@@ -1,40 +1,31 @@
-import { Web3Provider } from '@ethersproject/providers'
 import store from 'state'
 import { setPendingSign } from 'state/application/actions'
+import { useSignMessage as useSignMessageWagmi } from 'wagmi'
 
-interface Props {
-  hash?: string
-  account?: string | null
-  provider?: Web3Provider
+interface SignMessageProps {
+  hash: string
+  account: string
 }
-export const sign = async ({ hash, account, provider }: Props) => {
-  if (provider && hash && account) {
-    try {
-      store.dispatch(setPendingSign(true))
 
-      const result = await provider.send('personal_sign', [hash, account])
+// Custom hook for signing messages
+export const useSignMessage = () => {
+  const { signMessageAsync } = useSignMessageWagmi()
 
-      store.dispatch(setPendingSign(false))
-
-      return result
-    } catch (e) {
-      store.dispatch(setPendingSign(false))
-
-      console.error({ ERROR: e })
+  const signMessage = async ({ hash, account }: SignMessageProps): Promise<string | null> => {
+    if (hash && account) {
+      try {
+        store.dispatch(setPendingSign(true))
+        const result = await signMessageAsync({ message: { raw: hash as any } })
+        store.dispatch(setPendingSign(false))
+        return result
+      } catch (e) {
+        store.dispatch(setPendingSign(false))
+        console.error({ ERROR: e })
+        return null
+      }
     }
+    return null
   }
-  return null
-}
 
-// const getLoginMessage = ({ hash, account }: { hash: string; account: string }) => {
-//   return `
-// Welcome to IX Swap!\n
-// You need to sign in in order to access features related to security tokens.\n You only need to click "Sign".\n No username or password is needed. This request will not cost any gas fees.\n By signing in you agree to IXSwap’s Terms and Conditions (https://ixswap.io/terms-and-conditions/),
-// and acknowledge that you have read and understood the IX Swap Privacy Policy (https://ixswap.io/privacy-policy/).\n
-// Wallet Address:
-// \t${account} \n
-// Hash:
-// \t${hash} \n
-// To the moon!
-// `
-// }
+  return { signMessage }
+}

--- a/src/hooks/useFetchAccessToken.ts
+++ b/src/hooks/useFetchAccessToken.ts
@@ -1,7 +1,7 @@
 import apiService from 'services/apiService'
 import { metamask } from 'services/apiUrls'
 import { login } from './login'
-import { sign } from './personalSign'
+import { useSignMessage } from './personalSign'
 import { useWeb3React } from 'hooks/useWeb3React'
 import { useCallback } from 'react'
 
@@ -20,6 +20,8 @@ const ERROR_MESSAGES = {
 export const useFetchAccessToken = () => {
   const { account, provider } = useWeb3React()
 
+  const { signMessage } = useSignMessage()
+
   const fetchAccessToken = useCallback(async () => {
     if (!account || !provider) {
       throw new Error(ERROR_MESSAGES.noWallet)
@@ -29,7 +31,7 @@ export const useFetchAccessToken = () => {
       if (!data.hash) {
         throw new Error(ERROR_MESSAGES.noHashReceived)
       }
-      const result = await sign({ hash: data.hash, account, provider })
+      const result = await signMessage({ hash: data.hash, account })
       if (!result) {
         throw new Error(ERROR_MESSAGES.loginSignFailed)
       }


### PR DESCRIPTION
## Description

Sometimes we can't sign message. Click on Sign -> doesn't do anything 

Got the errro 

"{"code":-32600,"message":"Unsupported method: personal_sign. See available methods at https://docs.alchemy.com/alchemy/documentation/apis"}"

## Changes
-  Replace old implementation with useSignMessage from Wagmi

## Attached Links

1. Jira ticket: https://investax.atlassian.net/browse/IXSPD1-1990
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
