### PR TITLE
Favour injected provider for useWeb3React hook

### DIFF
--- a/src/hooks/useWeb3React.ts
+++ b/src/hooks/useWeb3React.ts
@@ -2,18 +2,21 @@ import { useAccount } from 'hooks/useAccount'
 import { useEthersProvider } from 'hooks/useEthersProvider'
 import { useMemo } from 'react'
 import { ChainId } from 'types/chains'
+import { Web3Provider } from '@ethersproject/providers'
 
 export function useWeb3React() {
   const account = useAccount()
   const chainId = account?.chain?.id ?? ChainId.Base
   const provider = useEthersProvider({ chainId })
+  // Fallback to a wallet provider (e.g., MetaMask) if available for sending transactions
+  const walletProvider = typeof window !== 'undefined' && window.ethereum ? new Web3Provider(window.ethereum) : provider
 
   return useMemo(
     () => ({
       account: account.address,
       chainId,
-      provider,
+      provider: walletProvider,
     }),
-    [account.address, account.chainId, provider],
+    [account.address, account.chainId, provider]
   )
 }


### PR DESCRIPTION
## Description

Favour injected provider for useWeb3React hook


Somtimes, we got the issue when execute transaction. The app is using rpc provider without a signer
```
{
    "jsonrpc": "2.0",
    "id": 122,
    "error": {
        "code": -32600,
        "message": "Unsupported method: eth_sendTransaction. See available methods at https://docs.alchemy.com/alchemy/documentation/apis"
    }
}
```

## Attached Links

1. Jira ticket:
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
