### PR TITLE
Ixspd1-2056 fe dev display only 1 required network when user access a deal rwa detail pages

### DIFF
--- a/src/components/Launchpad/NetworkNotAvailable/index.tsx
+++ b/src/components/Launchpad/NetworkNotAvailable/index.tsx
@@ -10,7 +10,6 @@ interface Props {
 }
 
 export const NetworkNotAvailable: React.FC<Props> = ({ expectChain }) => {
-  console.log('expectChain', expectChain)
   const { chainId } = useWeb3React()
   const { chains, switchChain } = useSwitchChain()
 
@@ -20,7 +19,6 @@ export const NetworkNotAvailable: React.FC<Props> = ({ expectChain }) => {
     }
   }
 
-  console.log('chains', chains)
   const chainsFiltered = chains.filter((chain) => chain.id === expectChain)
   const chainsNames = chainsFiltered.map((chain) => chain.name)
 

--- a/src/components/Launchpad/NetworkNotAvailable/index.tsx
+++ b/src/components/Launchpad/NetworkNotAvailable/index.tsx
@@ -10,6 +10,7 @@ interface Props {
 }
 
 export const NetworkNotAvailable: React.FC<Props> = ({ expectChain }) => {
+  console.log('expectChain', expectChain)
   const { chainId } = useWeb3React()
   const { chains, switchChain } = useSwitchChain()
 
@@ -19,6 +20,7 @@ export const NetworkNotAvailable: React.FC<Props> = ({ expectChain }) => {
     }
   }
 
+  console.log('chains', chains)
   const chainsFiltered = chains.filter((chain) => chain.id === expectChain)
   const chainsNames = chainsFiltered.map((chain) => chain.name)
 
@@ -30,8 +32,8 @@ export const NetworkNotAvailable: React.FC<Props> = ({ expectChain }) => {
         Blockchain Network
       </Title>
       <Info>Available Blockchain Networks:</Info>
-      <NetworksRow elements={chains.length} style={chains.length === 1 ? { marginLeft: 70, marginRight: 70 } : {}}>
-        {chains.map((chain) => (
+      <NetworksRow elements={chainsFiltered.length} style={chainsFiltered.length === 1 ? { marginLeft: 70, marginRight: 70 } : {}}>
+        {chainsFiltered.map((chain) => (
           <NetworkCard onClick={() => changeNetwork(chain.id)} key={chain.id}>
             <img src={CHAIN_INFO[chain.id].logoUrl} alt="icon" />
             {chain.name}


### PR DESCRIPTION
## Description

Please describe the purpose of this pull request.

## Changes

- Display only 1 required network when user access a deal/RWA detail pages
-
-

## Attached Links

1. Jira ticket: https://investax.atlassian.net/browse/IXSPD1-2056
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
