### PR TITLE
IXSPD1-2110 Rainbowkit -WalletConnect- Zerion is disconnected if user connected C…

### DIFF
--- a/src/state/auth/hooks.ts
+++ b/src/state/auth/hooks.ts
@@ -68,7 +68,12 @@ export function useLogout() {
     dispatch(setWalletState({ isConnected: false, walletName: '', isSignLoading: false }))
     dispatch(clearUserData())
     dispatch(clearEventLog())
-    indexedDB?.deleteDatabase('WALLET_CONNECT_V2_INDEXED_DB')
+    const deletedIndexDB = localStorage.getItem('deletedIndexDB')
+
+    if (deletedIndexDB && deletedIndexDB !== 'true') {
+      indexedDB?.deleteDatabase('WALLET_CONNECT_V2_INDEXED_DB')
+      localStorage.setItem('deletedIndexDB', 'true')
+    }
   }
 
   return { disconnectWallet }


### PR DESCRIPTION
…oinBase previously

## Description

Please describe the purpose of this pull request.

## Changes

- Rainbowkit -WalletConnect- Zerion is disconnected if user connected CoinBase previously
-
-

## Attached Links

1. Jira ticket: https://investax.atlassian.net/browse/IXSPD1-2110
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
