### PR TITLE
Ixspd1-2265 fe dev multichain investing token cannot be displayed on the issuance form with kaia or ozean chain

### DIFF
--- a/src/components/LaunchpadIssuance/IssuanceForm/Information/InformationForm.tsx
+++ b/src/components/LaunchpadIssuance/IssuanceForm/Information/InformationForm.tsx
@@ -195,8 +195,12 @@ export const InformationForm = (props: Props) => {
 
   useEffect(() => {
     if (values.network) {
+      const options = tokenTypeOptionsByNetwork[values.network];
       setTokenTypeOptions(tokenTypeOptionsByNetwork[values.network])
-      setFieldValue('tokenType', undefined)
+
+      if (options && !options.find((option: any) => option.value === values.tokenType)) {
+        setFieldValue('tokenType', undefined)
+      }
     }
   }, [values.network])
 

--- a/src/components/LaunchpadIssuance/IssuanceForm/Information/InformationForm.tsx
+++ b/src/components/LaunchpadIssuance/IssuanceForm/Information/InformationForm.tsx
@@ -195,8 +195,8 @@ export const InformationForm = (props: Props) => {
 
   useEffect(() => {
     if (values.network) {
-      const options = tokenTypeOptionsByNetwork[values.network];
-      setTokenTypeOptions(tokenTypeOptionsByNetwork[values.network])
+      const options = tokenTypeOptionsByNetwork[values.network]
+      setTokenTypeOptions(options)
 
       if (options && !options.find((option: any) => option.value === values.tokenType)) {
         setFieldValue('tokenType', undefined)


### PR DESCRIPTION
… with Kaia or Ozean chain

## Description

Please describe the purpose of this pull request.

## Changes

- Multichain - Investing Token cannot be displayed on the issuance form with Kaia or Ozean chain
-
-

## Attached Links

1. Jira ticket: https://investax.atlassian.net/browse/IXSPD1-2265
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments
