### PR TITLE
fix: [IXSPD1-2447] validate presaleTokenPrice when the hasPresale is enable

### DIFF
--- a/src/components/LaunchpadIssuance/IssuanceForm/Information/schema.ts
+++ b/src/components/LaunchpadIssuance/IssuanceForm/Information/schema.ts
@@ -122,11 +122,18 @@ export const createValidationSchema = (account: string | null | undefined) => {
     presaleTokenPrice: yup
       .string()
       .nullable()
-      .test('notZero', 'Pre-sale Token price should be bigger than 0!', function () {
-        const { originalValue } = this as any
-        return !originalValue || +originalValue > 0
-      })
-      .required(REQUIRED),
+      .when('hasPresale', {
+        is: true,
+        then: yup
+          .string()
+          .nullable()
+          .required(REQUIRED)
+          .test('notZero', 'Pre-sale Token price should be bigger than 0!', function () {
+            const { originalValue } = this as any
+            return !originalValue || +originalValue > 0
+          }),
+        otherwise: yup.string().nullable(),
+      }),
     tokenStandart: yup.string().nullable().oneOf(Object.values(OfferTokenStandart)).required(REQUIRED),
 
     tokenReceiverAddress: yup


### PR DESCRIPTION

## Description

Please describe the purpose of this pull request.

## Changes

- validate presaleTokenPrice when the hasPresale is enable
-
-

## Attached Links

1. Jira ticket: [IXSPD1-2447]
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments


[IXSPD1-2447]: https://investax.atlassian.net/browse/IXSPD1-2447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ