### PR TITLE
fix: [IXSPD1-2458] convert presale price into string once update offer

### DIFF
--- a/src/state/launchpad/hooks.ts
+++ b/src/state/launchpad/hooks.ts
@@ -1273,7 +1273,7 @@ export const useSubmitOffer = () => {
         maxInvestment: payload.maxInvestment,
 
         hasPresale: payload.hasPresale,
-        presaleTokenPrice: payload.presaleTokenPrice,
+        presaleTokenPrice: payload.presaleTokenPrice?.toString(),
         presaleMinInvestment: payload.presaleMinInvestment,
         presaleMaxInvestment: payload.presaleMaxInvestment,
         presaleAlocated: payload.presaleAlocated,


### PR DESCRIPTION
## Description

Please describe the purpose of this pull request.

## Changes

- convert presale price into string once update offer
-
-

## Attached Links

1. Jira ticket: [IXSPD1-2458]
2. Documents:

## Checklist

- [x] Manual tests
- [x] The pull request doesn't affect existing feature

## For reviewers

- Ensure new code doesn't break existing features
- Reviewer shouldn't merge if there are pending unresolved comments


[IXSPD1-2458]: https://investax.atlassian.net/browse/IXSPD1-2458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ